### PR TITLE
Change default $ssl_certs_dir to undef to address overly broad auth issues

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,6 +49,9 @@ class apache::params inherits ::apache::version {
 
   $modsec_audit_log_parts = 'ABIJDEFHZ'
 
+  # no client certs should be trusted for auth by default.
+  $ssl_certs_dir          = undef 
+
   if ($::operatingsystem == 'Ubuntu' and $::lsbdistrelease == '10.04') or ($::operatingsystem == 'SLES') {
     $verify_command = '/usr/sbin/apache2ctl -t'
   } elsif $::operatingsystem == 'FreeBSD' {
@@ -83,7 +86,6 @@ class apache::params inherits ::apache::version {
     $dev_packages         = 'httpd-devel'
     $default_ssl_cert     = '/etc/pki/tls/certs/localhost.crt'
     $default_ssl_key      = '/etc/pki/tls/private/localhost.key'
-    $ssl_certs_dir        = '/etc/pki/tls/certs'
     $ssl_sessioncache     = '/var/cache/mod_ssl/scache(512000)'
     $passenger_conf_file  = 'passenger_extra.conf'
     $passenger_conf_package_file = 'passenger.conf'
@@ -223,7 +225,6 @@ class apache::params inherits ::apache::version {
     $mpm_module          = 'worker'
     $default_ssl_cert    = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
     $default_ssl_key     = '/etc/ssl/private/ssl-cert-snakeoil.key'
-    $ssl_certs_dir       = '/etc/ssl/certs'
     $ssl_sessioncache    = "\${APACHE_RUN_DIR}/ssl_scache(512000)"
     $suphp_addhandler    = 'x-httpd-php'
     $suphp_engine        = 'off'
@@ -389,7 +390,6 @@ class apache::params inherits ::apache::version {
     $dev_packages     = undef
     $default_ssl_cert = '/usr/local/etc/apache24/server.crt'
     $default_ssl_key  = '/usr/local/etc/apache24/server.key'
-    $ssl_certs_dir    = undef
     $ssl_sessioncache  = '/var/run/ssl_scache(512000)'
     $passenger_conf_file = 'passenger.conf'
     $passenger_conf_package_file = undef
@@ -459,7 +459,6 @@ class apache::params inherits ::apache::version {
     $dev_packages     = undef
     $default_ssl_cert = '/etc/ssl/apache2/server.crt'
     $default_ssl_key  = '/etc/ssl/apache2/server.key'
-    $ssl_certs_dir    = '/etc/ssl/apache2'
     $ssl_sessioncache  = '/var/run/ssl_scache(512000)'
     $passenger_root   = '/usr'
     $passenger_ruby   = '/usr/bin/ruby'
@@ -528,7 +527,6 @@ class apache::params inherits ::apache::version {
     $mpm_module          = 'prefork'
     $default_ssl_cert    = '/etc/apache2/ssl.crt/server.crt'
     $default_ssl_key     = '/etc/apache2/ssl.key/server.key'
-    $ssl_certs_dir       = '/etc/ssl/certs'
     $ssl_sessioncache    = '/var/lib/apache2/ssl_scache(512000)'
     $suphp_addhandler    = 'x-httpd-php'
     $suphp_engine        = 'off'


### PR DESCRIPTION
If $ssl_certs_dir defaults to a location that contains certificates, apache will trust implicitly all the certificates presented by the client for auth that were issues by *any* certificates in that location. 

Note: 
 * In Gentoo, $ssl_certs_dir was pointing to /etc/apache2/ssl, which may have been safe, or used for storing CA certs to check client auth. Gentoo users may need to set that value explicitly after upgrade.

For more details, see [MODULE-5471]